### PR TITLE
fix: asciidoctor warnings and errors

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-= code-coffee-compendium image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/View%20on-GitHub-orange[View on GitHub, link=https://github.com/LearnTeachCode/code-coffee-compendium/]
+== code-coffee-compendium image:https://img.shields.io/badge/License-MIT-yellow.svg[MIT License, link=https://opensource.org/licenses/MIT] image:https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square[PRs Welcome, link=http://makeapullrequest.com] image:https://img.shields.io/badge/View%20on-GitHub-orange[View on GitHub, link=https://github.com/LearnTeachCode/code-coffee-compendium/]
 
 image:./logo/code&coffeelogo.svg[logo,246,139]
 

--- a/header.adoc
+++ b/header.adoc
@@ -3,7 +3,7 @@
 :toclevels: 4
 :source-highlighter: coderay
 
-=== <<index.adoc#,Return to the Homepage>>
+== <<index.adoc#,Return to the Homepage>>
 
 image:./logo/code&coffeelogo.svg[logo,246,139]
 


### PR DESCRIPTION
I'm still not sure what this error is 🤷‍♀️ 
```bash
# ruby convert.rb
asciidoctor: ERROR: sitemap.adoc: line 9: Failed to generate image: PlantUML image generation failed: [From <input> (line 2) ]
                        
@startuml               
                        
^^^^^                   
 Empty description      

Sitemap generated successfully.
```